### PR TITLE
avoid UB (left shift of negative number) in `SDL_windowsevents.c`

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1640,7 +1640,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             POINT cursorPos;
             GetCursorPos(&cursorPos);
             ScreenToClient(hwnd, &cursorPos);
-            PostMessage(hwnd, WM_MOUSEMOVE, 0, cursorPos.x | cursorPos.y << 16);
+            PostMessage(hwnd, WM_MOUSEMOVE, 0, cursorPos.x | (((unsigned int)((short)cursorPos.y)) << 16));
         }
     } break;
 


### PR DESCRIPTION
Fixes UB introduced in https://github.com/libsdl-org/SDL/commit/69d28027adb70daf962621bb5e8ab00a069cbe30, reported downstream in https://github.com/david-vanderson/dvui/issues/198 .
(libsdl-org upstream PR: https://github.com/libsdl-org/SDL/pull/12505 )

This formulation first asserts that the value is in bounds for `short` (`i16`),
then converts & promotes the value to `unsigned int` (`u32`) to ensure the shift is legal.

The alternative would be to simply `& 0xFFFF` the operand.
This would hide any out-of-bounds values for `i16` (`< SHRT_MIN` or `> SHRT_MAX`), which I didn't like as much.

From my testing, this fixes the reported crash (detected UB) when clicking on a window's title bar.